### PR TITLE
Remove problematic licensed files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ categories = ["text-processing", "internationalization"]
 description = "Library for handling Unicode functionality for finl (categories and grapheme segmentation)"
 homepage = "https://finl.xyz"
 repository = "https://github.com/dahosek/finl_unicode"
+exclude = ["resources"]
 
 [dependencies]
 


### PR DESCRIPTION
Specifically it's about the unicode licensed file `grapmemes.txt`.

License `Unicode-DFS-2016` is accepted, but the license described is dubious
> Copyright © 1991–2022 Unicode, Inc. All rights reserved.

This makes us believe it is not distributed under a free license, which is problematic for packaging